### PR TITLE
Fix `get_reference_model.sh`

### DIFF
--- a/get_reference_model.sh
+++ b/get_reference_model.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
 echo "downloading the model from dropbox..."
-wget https://www.dropbox.com/scl/fi/czdlt2zc2ji2b7zd0pvoe/reference_model.tar.gz?rlkey=56ebq4g5dk01kyq8kuismev14
-
-echo "cleaning the filename..."
-mv reference_model.tar.gz?rlkey=ec9igxl3i57llwxubb294syf9 reference_model.tar.gz
+wget https://www.dropbox.com/scl/fi/czdlt2zc2ji2b7zd0pvoe/reference_model.tar.gz?rlkey=56ebq4g5dk01kyq8kuismev14 \
+  -O reference_model.tar.gz
 
 echo "extracting from tar..."
 tar -xvf reference_model.tar.gz


### PR DESCRIPTION
The rlkey is different between the wget and mv lines.
I add `-O reference_model.tar.gz` to the wget command and removed the mv command.